### PR TITLE
【fix】EC：バグ修正：管理画面・住所一覧の変更完了

### DIFF
--- a/laracom/project/resources/views/admin/addresses/list.blade.php
+++ b/laracom/project/resources/views/admin/addresses/list.blade.php
@@ -26,7 +26,7 @@
                         <tbody>
                         @foreach ($addresses as $address)
                             <tr>
-                                <td><a href="{{ route('admin.customers.show', [$address->customer_id]) }}">{{ $address->alias }}</a></td>
+                                <td><a href="{{ route('admin.customers.show', [$address->id]) }}">{{ $address->alias }}</a></td>
                                 <td>{{ $address->address_1 }}</td>
                                 <td>{{ $address->country }}</td>
                                 <td>{{ $address->province }}</td>


### PR DESCRIPTION
実装方針
---
概要：

admin.customers.showに適切な値を引き渡すよう修正を行う

方針：
・エラーが発生するアドレス、http://localhost:8000/admin/addresses のURLを
　http://localhost:8000/admin/addresses/1 に修正、アクセス

・アクセスし、無事画面が表示されたことから、他の一覧画面同様idによるリンク生成が必要であると推測

・以下の箇所のみcustomer_idが使われていることを確認、修正
`<td><a href="{{ route('admin.customers.show', [$address->customer_id]) }}">{{ $address->alias }}</a></td>`
↓
`<td><a href="{{ route('admin.customers.show', [$address->id]) }}">{{ $address->alias }}</a></td>`

・動作確認を行いエラー等は見受けられなかったため、PR

動作確認
---
・画面が問題なく表示されていることを確認
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/f9677a9f-b387-4df5-b49d-a409eaa4384f)
・リンクが機能していることを確認（一枚目左下のリンクをご確認ください）
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/51e3318c-59f4-408f-8ca0-21dc944628be)
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/5b3cbad1-b4ae-4666-b979-d093a29d8625)

・editボタンのリンクが機能していることを確認（一枚目左下のリンクをご確認ください）
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/e824a462-824a-4494-93ab-e3ee46832a80)
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/bb01bbc3-4abf-4587-ad82-4ccf34e53fe8)

・deleteボタンが機能していることを確認（スクショを取り損ねてしまって、別データです）
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/387e03ce-aabc-4db1-9296-42ee7c5fd91c)
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/9cf06183-0ea1-4e73-9410-40775bdabc82)

・検索機能の動作を確認
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/2de6719a-095e-451d-ae3a-ec8c714c7ad2)
![image](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/6d8370ad-8d77-4d4d-9af1-602a13587ee4)



