### PR TITLE
【Feature】 EC：デザインを変更してユーザー体験を向上させよう

### DIFF
--- a/laracom/project/resources/assets/css/front.css
+++ b/laracom/project/resources/assets/css/front.css
@@ -60,7 +60,7 @@ p {
     line-height: 25px;
     font-weight: 400;
     margin-bottom: 15px;
-    margin-top: 0px;
+    margin-top: 30px;
 }
 a {
     color: #d89522;
@@ -525,7 +525,7 @@ textarea, select {
     bottom: 0;
     width: 100%;
     /* Set the fixed height of the footer here */
-    height: 60px;
+    height: 70px;
     background-color: #f5f5f5;
 }
 

--- a/laracom/project/resources/views/layouts/front/footer.blade.php
+++ b/laracom/project/resources/views/layouts/front/footer.blade.php
@@ -9,13 +9,6 @@
                     <li> <a href="">Terms of service</a>  </li>
                 </ul>
 
-                <ul class="footer-social">
-                    <li> <a href=""> <i class="fa fa-facebook" aria-hidden="true"></i>  </a> </li>
-                    <li> <a href=""> <i class="fa fa-twitter" aria-hidden="true"></i>   </a> </li>
-                    <li> <a href=""> <i class="fa fa-instagram" aria-hidden="true"></i>  </a> </li>
-                    <li> <a href=""> <i class="fa fa-pinterest-p" aria-hidden="true"></i>  </a> </li>
-                </ul>
-
                 <p>&copy; <a href="{{ config('app.url') }}">{{ config('app.name') }}</a> | All Rights Reserved</p>
 
             </div>

--- a/laracom/project/resources/views/layouts/front/product.blade.php
+++ b/laracom/project/resources/views/layouts/front/product.blade.php
@@ -31,8 +31,15 @@
     </div>
     <div class="col-md-6">
         <div class="product-description">
-            <h1>{{ $product->name }}
-                <small>{{ config('cart.currency') }} {{ $product->price }}</small>
+            <h1>
+                <span style="font-weight: bold;">{{ $product->name }}
+                <br>
+                <br>
+                <b>
+                    <span style="color: red;">{{ $product->price * 140 }}<small>{{ config('cart.currency_symbol') }}</span>
+                    <span style="color: black;">+ 送料980円</span>
+                </b>
+                <small>SKU:{{ $product->sku }}</small>
             </h1>
             <div class="description">{!! $product->description !!}</div>
             <hr>
@@ -67,7 +74,7 @@
                                 placeholder="Quantity" value="{{ old('quantity') }}" />
                             <input type="hidden" name="product" value="{{ $product->id }}" />
                         </div>
-                        <button type="submit" class="btn btn-warning"><i class="fa fa-cart-plus"></i> Add to cart
+                        <button type="submit" class="btn btn-warning"><i class="fa fa-cart-plus"></i> かごに追加
                         </button>
                     </form>
                 </div>


### PR DESCRIPTION
概要：
---
1. 画面レイアウトを画面仕様に従い修正
2. 価格は日本円表示にし、１ドル140円で計算 
3. 価格の右横に送料980円を表示
4. SKUを表示
5. 「かごに追加」に用語を変更
6. モバイルに対応するようレスポシンプルに変更

方針：
---
>1. 画面レイアウトを画面仕様に従い修正
 
・商品名を太字に修正
・商品の価格を赤字に変更

>2. 価格は日本円表示にし、１ドル140円で計算 

・日本円表記にし、シンボルを円に変更
・blade内にて商品の価格に140を乗算する処理を追加
・envファイルの下記の値を修正、php artisan config:clear 及び config:cacheでconfigに反映し、値を取得
```
DEFAULT_CURRENCY=JPY
CURRENCY_SYMBOL=円
```
>3. 価格の右横に送料980円を表示

・以下のspanタグを追加表示させることで対応
```
<span style="color: black;">+ 送料980円</span>
```

>4. SKUを表示

・smallタグ内部を以下に変更
```
SKU:{{ $product->sku }}
```

>5. 「かごに追加」に用語を変更

・buttonタグ内部のadd to cartをかごに追加に変更

>6. モバイルに対応するようレスポシンプルに変更

・footer以外の箇所は事前にレスポンシブル化されていたため、そのまま
・footerだけレスポンシブル化した際、リンクの見切れが発生したため、対処することを決定
・cssでfooterの背景黒枠に使われているheightを10px追加
・追加した際隠れていたSNSアイコンが表示されてしまうので、山野さんに確認して以下のSNSボタンに関するコードを撤去
```
                <ul class="footer-social">
                    <li> <a href=""> <i class="fa fa-facebook" aria-hidden="true"></i>  </a> </li>
                    <li> <a href=""> <i class="fa fa-twitter" aria-hidden="true"></i>   </a> </li>
                    <li> <a href=""> <i class="fa fa-instagram" aria-hidden="true"></i>  </a> </li>
                    <li> <a href=""> <i class="fa fa-pinterest-p" aria-hidden="true"></i>  </a> </li>
                </ul>
```
・footerを伸ばした分、直下のpタグの文字が文字の半分だけ黒枠内に入ってしまう問題が発生したため、pタグのmargin-topを30px加算

実装後の画面
---
**PC画面：**
![スクリーンショット 2024-01-25 124114](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/d84eceac-3d28-48da-aecb-b238e9154906)

**スマホ画面：iphoneSEでの表示**
![スクリーンショット 2024-01-25 125544](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/8f3d9c39-5bd6-48c0-bbb6-9373a20d3f7e)
![スクリーンショット 2024-01-25 125552](https://github.com/ksaitodc/lxp-practical-project/assets/102935257/7a382b0b-f4af-4aeb-b805-146c1090fa47)


